### PR TITLE
Fix off-by-one sourcemap error.

### DIFF
--- a/lib/js/sourcemap.js
+++ b/lib/js/sourcemap.js
@@ -36,6 +36,7 @@ function Sourcemap() {
  */
 
 Sourcemap.prototype.file = function(file, src, wrapped) {
+  var offset = wrapperOffset(src, wrapped);
   src = src.replace(rsourcemap, '');
   this.sm.addFile({ sourceFile: file, source: src }, { line: this.lineno });
   this.lineno += lineno(wrapped || src);
@@ -64,4 +65,18 @@ function lineno(src) {
   if (!src) return 0;
   var m = src.match(/\n/g);
   return m ? m.length + 1: 0;
+}
+
+/**
+ * Get the number of lines prepended by wrapper
+ *
+ * @param {String} src
+ * @param {String} wrapper
+ * @return {Number}
+ * @api private
+ */
+
+function wrapperOffset(src, wrapped) {
+  if (!src || (src && !wrapped)) return 0;
+  return wrapped.substr(0, wrapped.indexOf(src)).match(/\n/g).length;
 }

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
     "co-mocha": "*",
     "co-fs": "*"
   },
-  "main": "index.js"
+  "main": "index.js",
+  "scripts": {
+    "test": "mocha --harmony-generators"
+  }
 }


### PR DESCRIPTION
The packing process now accounts for the lines prepended to the original
source when wrapped.

This should resolve duojs/duo#125 but does not fix the failing sourcemaps test here in pack.
