### PR TITLE
add umd support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -13,8 +13,20 @@
 ## Example
 
 ```js
+// Simple.
+
 var mapping = require('./components/duo.json');
 var pack = Pack(mapping);
+
+var js = pack.pack('main.js');
+var css = pack.pack('main.js');
+```
+
+```js
+// UMD.
+
+var mapping = require('./components/duo.json');
+var pack = Pack(mapping, { umd: true });
 
 var js = pack.pack('main.js');
 var css = pack.pack('main.js');

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,14 +14,15 @@ var css = Pack.css = require('./css');
 /**
  * Initialize `Pack`
  *
- * @param {String} root
  * @param {Object} mapping
+ * @param {Object} opts
  * @return {Pack}
  * @api public
  */
 
-function Pack(mapping) {
-  if (!(this instanceof Pack)) return new Pack(mapping);
+function Pack(mapping, opts) {
+  if (!(this instanceof Pack)) return new Pack(mapping, opts);
+  this.opts = opts || {};
   this.mapping = mapping;
   this.develop = false;
 }

--- a/lib/js/index.js
+++ b/lib/js/index.js
@@ -7,6 +7,7 @@ var sourcemap = require('./sourcemap');
 var fmt = require('util').format;
 var req = require('./require');
 var stringify = JSON.stringify;
+var umd = require('./umd');
 var ids = {};
 var uid = 0;
 
@@ -30,6 +31,7 @@ function JS(entry, mapping, pack) {
   if (!(this instanceof JS)) return new JS(entry, mapping, pack);
   this.sm = pack.develop ? sourcemap() : false;
   this.mapping = mapping;
+  this.opts = pack.opts;
   this.entry = entry;
   this.pack = pack;
   this.ids = {};
@@ -57,6 +59,14 @@ JS.prototype.toString = function() {
   var id = this.remap(this.entry).id;
   var m = {};
   m[id] = entry.global || '';
+
+  // umd support.
+  if (this.opts.umd && this.entry.name) {
+    str = fmt('%s(%s);', umd
+      .replace(/:entry/g, this.entry.name)
+      .replace(/:id/g, id)
+      , str);
+  }
 
   return fmt(str, req, join(src), stringify(m), sm ? sm.end() : '');
 };

--- a/lib/js/umd.js
+++ b/lib/js/umd.js
@@ -1,0 +1,22 @@
+
+/**
+ * Expose `umd`
+ */
+
+module.exports = (function(){
+  return '(' + umd + ')';
+})();
+
+/**
+ * UMD.
+ */
+
+function umd(require){
+  if ('object' == typeof exports) {
+    module.exports = require(':id');
+  } else if ('function' == typeof define && define.amd) {
+    define(function(){ return require(':id'); });
+  } else {
+    this[':entry'] = require(':id');
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -52,6 +52,38 @@ describe('Pack', function(){
     assert.deepEqual(['console', 'require'], globals)
   })
 
+  it('should support umd (amd)', function(){
+    var defs = [];
+    var map = {};
+    map.module = { id: 'module', type: 'js', entry: true, src: 'module.exports = [];', deps: {}, name: 'module' };
+    var define = defs.push.bind(defs);
+    define.amd = true;
+    var pack = Pack(map, { umd: true });
+    var js = pack.pack('module');
+    var ctx = evaluate(js, { define: define });
+    assert(Array.isArray(defs[0]()));
+  })
+
+  it('should support umd (commonjs)', function(){
+    var mod = { exports: {} };
+    var map = {};
+    map.module = { id: 'module', type: 'js', entry: true, src: 'module.exports = []', deps: {}, name: 'module' };
+    var pack = Pack(map, { umd: true });
+    var js = pack.pack('module');
+    var ctx = evaluate(js, { module: mod, exports: mod.exports });
+    assert(Array.isArray(ctx.module.exports));
+  });
+
+  it('should support umd (global)', function(){
+    var global = {};
+    var map = {};
+    map.module = { id: 'module', type: 'js', entry: true, src: 'module.exports = []', deps: {}, name: 'module' };
+    var pack = Pack(map, { umd: true });
+    var js = pack.pack('module');
+    var ctx = evaluate(js, global);
+    assert(Array.isArray(ctx.module));
+  });
+
   it('should not use previously defined require()s', function(){
     var map = {};
     map.module = { id: 'module', type: 'js', entry: true, src: 'module.exports = "module"', deps: {} };


### PR DESCRIPTION
Adds simple umd support like component had (duojs/duo#360).
We can back this feature with `duo --standalone <name>`, `duo --umd <name>`

@MatthewMueller @stephenmathieson
