### PR TITLE
Fix off-by-one sourcemap bug

### DIFF
--- a/lib/js/sourcemap.js
+++ b/lib/js/sourcemap.js
@@ -38,7 +38,7 @@ function Sourcemap() {
 Sourcemap.prototype.file = function(file, src, wrapped) {
   var offset = wrapperOffset(src, wrapped);
   src = src.replace(rsourcemap, '');
-  this.sm.addFile({ sourceFile: file, source: src }, { line: this.lineno });
+  this.sm.addFile({ sourceFile: file, source: src }, { line: this.lineno + offset });
   this.lineno += lineno(wrapped || src);
 };
 


### PR DESCRIPTION
This just applies the wrapper offset that @ryanfields created with #24 (3380e5e).