### PR TITLE
not caching module until successful resolve (fixes duojs/duo#421)

### DIFF
--- a/lib/js/require.js
+++ b/lib/js/require.js
@@ -47,15 +47,18 @@ function outer(modules, cache, entries){
    */
 
   function call(id, require){
-    var m = cache[id] = { exports: {} };
+    var m = { exports: {} };
     var mod = modules[id];
     var name = mod[2];
     var fn = mod[0];
 
     fn.call(m.exports, function(req){
       var dep = modules[id][1][req];
-      return require(dep ? dep : req);
+      return require(dep || req);
     }, m, m.exports, outer, modules, cache, entries);
+
+    // store to cache after successful resolve
+    cache[id] = m;
 
     // expose as `name`.
     if (name) cache[name] = cache[id];

--- a/test/fixtures/error-cache.js
+++ b/test/fixtures/error-cache.js
@@ -1,0 +1,13 @@
+exports.a = {
+  id: 'a',
+  type: 'js',
+  src: 'var b1, b2; try { b1 = require("./b"); } catch (err) { b1 = err; }\ntry { b2 = require("./b"); } catch (err) { b2 = err; }\nexports.b1 = b1; exports.b2 = b2;',
+  entry: true,
+  deps: { './b': 'b' }
+};
+
+exports.b = {
+  id: 'b',
+  type: 'js',
+  src: 'throw "fail";'
+};

--- a/test/index.js
+++ b/test/index.js
@@ -223,6 +223,15 @@ describe('Pack', function(){
     var css = pack.pack('some/dir/a');
     assert.equal('section { background: url("images/b.png"); }', css);
   })
+
+  it('should not cache broken packages', function() {
+    var map = require('./fixtures/error-cache');
+    var pack = Pack(map);
+    var js = pack.pack('a');
+
+    var ret = evaluate(js).require(1);
+    assert.strictEqual(ret.b1, ret.b2);
+  })
 })
 
 function evaluate(js, ctx){


### PR DESCRIPTION
By waiting to store the `module.exports` into the cache until _after_ a successful require, we avoid the confusion/error mentioned in duojs/duo#421.