### PR TITLE
Source maps improvements

### DIFF
--- a/lib/js/sourcemap.js
+++ b/lib/js/sourcemap.js
@@ -5,13 +5,6 @@
 var sourcemap = require('combine-source-map');
 
 /**
- * Sourcemap regex
- */
-
-var rsourcemap = /^[ \t]*\/\/[@#][ \t]+sourceMappingURL=data:(?:application|text)\/json;base64,(.+)/mg;
-rsourcemap.lastIndex = 0;
-
-/**
  * Export `Sourcemap`
  */
 
@@ -37,7 +30,6 @@ function Sourcemap() {
 
 Sourcemap.prototype.file = function(file, src, wrapped) {
   var offset = wrapperOffset(src, wrapped);
-  src = src.replace(rsourcemap, '');
   this.sm.addFile({ sourceFile: '/duo/' + file, source: src }, { line: this.lineno + offset });
   this.lineno += lineno(wrapped || src);
 };

--- a/lib/js/sourcemap.js
+++ b/lib/js/sourcemap.js
@@ -38,7 +38,7 @@ function Sourcemap() {
 Sourcemap.prototype.file = function(file, src, wrapped) {
   var offset = wrapperOffset(src, wrapped);
   src = src.replace(rsourcemap, '');
-  this.sm.addFile({ sourceFile: file, source: src }, { line: this.lineno + offset });
+  this.sm.addFile({ sourceFile: '/duo/' + file, source: src }, { line: this.lineno + offset });
   this.lineno += lineno(wrapped || src);
 };
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git://github.com/matthewmueller/duo-pack.git"
   },
   "dependencies": {
-    "combine-source-map": "^0.3.0",
+    "combine-source-map": "^0.4.0",
     "file-deps": "0.0.x",
     "gnode": "^0.1.0"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -122,7 +122,7 @@ describe('Pack', function(){
     var js = Pack(map).development().pack('m');
     var raw = rawSourceMap(js);
     var smc = new SourceMapConsumer(raw);
-    var actual = smc.sourceContentFor('m');
+    var actual = smc.sourceContentFor('/duo/m');
     assert.equal(map.m.src, actual);
   })
 


### PR DESCRIPTION
I'm so excited to make these 2 changes. (at long last!)

First, this adds a `/duo/` prefix to the source map address. In the Chrome debugger at least, I would get conflicts if the source-map file matched the input file. (which always happened for the entry files in duo-serve) This prefix keeps the source-maps distinct from the source-files.

Second, this adds initial support for transpiled languages. It turns out that `combine-source-map@0.4` added the ability to merge the inline source-map of a given file into the larger source-map. (I was using `duo-babel` for ES6 transpilation, and it worked beautifully) So long as each individual tool can process the inline-source map and merge it into the one it outputs, we're going to be golden. (I discovered this by looking at how browserify-pack accomplished this)

This makes *zero* API changes, so once we merge and release this, everything will automatically start to benefit. :)