### PR TITLE
Moving towards supporting external source-maps

### DIFF
--- a/lib/css/index.js
+++ b/lib/css/index.js
@@ -37,7 +37,19 @@ function CSS(entry, mapping, pack) {
  * @api public
  */
 
-CSS.prototype.toString = function() {
+CSS.prototype.run = function() {
+  return {
+    code: this.code()
+  };
+};
+
+/**
+ * Generate the CSS source code.
+ *
+ * @returns {String}
+ */
+
+CSS.prototype.code = function () {
   return this.pkg(this.entry).value;
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -57,5 +57,5 @@ Pack.prototype.pack = function(entry) {
   if (!Pack[type]) return false;
 
   // pack the source
-  return Pack[type](dep, mapping, this).toString();
+  return Pack[type](dep, mapping, this).run();
 };

--- a/lib/js/index.js
+++ b/lib/js/index.js
@@ -39,18 +39,31 @@ function JS(entry, mapping, pack) {
 }
 
 /**
- * Compile the mapping to a string
+ * Packs the entry/mapping into a single result object.
  *
- * @return {String}
+ * @returns {Object}
  * @api public
  */
 
-JS.prototype.toString = function() {
-  var str = '%s({\n%s}, {}, %s)\n%s';
+JS.prototype.run = function () {
+  return {
+    code: this.code(),
+    map: this.map()
+  }
+};
+
+/**
+ * Compile the mapping to a string
+ *
+ * @return {String}
+ */
+
+JS.prototype.code = function() {
+  var str = '%s({\n%s}, {}, %s)';
   var entry = this.entry;
-  // source map + src
-  var sm = this.sm;
-  sm && sm.file('require.js', req);
+
+  // add require to source-map
+  if (this.sm) this.sm.file('require.js', req);
 
   // build the source
   var src = this.pkg(this.entry);
@@ -60,7 +73,7 @@ JS.prototype.toString = function() {
   var m = {};
   m[id] = entry.global || '';
 
-  // umd support.
+  // umd support
   if (this.opts.umd && this.entry.name) {
     str = fmt('%s(%s);', umd
       .replace(/:entry/g, this.entry.name)
@@ -68,9 +81,19 @@ JS.prototype.toString = function() {
       , str);
   }
 
-  return fmt(str, req, join(src), stringify(m), sm ? sm.end() : '');
+  return fmt(str, req, join(src), stringify(m));
 };
 
+/**
+ * Returns the generated source-map.
+ *
+ * @reutrns {Object}
+ */
+
+JS.prototype.map = function () {
+  if (!this.sm) return false;
+  return this.sm.end();
+}
 
 /**
  * Package the deps
@@ -87,7 +110,6 @@ JS.prototype.pkg = function(dep, out) {
   if (out[dep.id]) return out;
 
   var id = dep.id;
-  var sm = this.sm;
   var src = dep.src;
   var deps = dep.deps;
   var remapped = this.remap(dep);
@@ -97,7 +119,7 @@ JS.prototype.pkg = function(dep, out) {
   out[id] = str;
 
   // add file to sourcemap
-  sm && sm.file(id, src, str);
+  if (this.sm) this.sm.file(id, src, str);
 
   // recurse through dep's deps
   for (var d in deps) {

--- a/lib/js/sourcemap.js
+++ b/lib/js/sourcemap.js
@@ -2,6 +2,7 @@
  * Module dependencies
  */
 
+var convert = require('convert-source-map');
 var sourcemap = require('combine-source-map');
 
 /**
@@ -42,7 +43,7 @@ Sourcemap.prototype.file = function(file, src, wrapped) {
  */
 
 Sourcemap.prototype.end = function() {
-  return '\n' + this.sm.comment();
+  return convert.fromBase64(this.sm.base64()).toObject();
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "combine-source-map": "^0.4.0",
+    "convert-source-map": "^0.5.0",
     "file-deps": "0.0.x",
     "gnode": "^0.1.0"
   },


### PR DESCRIPTION
This changes the pack API to return a `{ code, map }` object. This is a breaking API change, so this will bump `minor` at least.

We will need to add the `convert-source-map` dep to duo, but this will allow us to support:
 - no source-maps
 - inline source-maps
 - external source-maps (new)