### PR TITLE
Improving source-maps internally

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,7 @@ function Pack(mapping, opts) {
   if (!(this instanceof Pack)) return new Pack(mapping, opts);
   this.opts = opts || {};
   this.mapping = mapping;
-  this.develop = false;
+  this.sourceMap(false);
 }
 
 /**
@@ -35,8 +35,9 @@ function Pack(mapping, opts) {
  * @api public
  */
 
-Pack.prototype.development = function(develop) {
-  this.develop = undefined == develop ? true : develop;
+Pack.prototype.sourceMap = function(value) {
+  if (typeof value === 'undefined') return this.sm;
+  this.sm = value;
   return this;
 };
 

--- a/lib/js/index.js
+++ b/lib/js/index.js
@@ -79,26 +79,22 @@ JS.prototype.code = function() {
   if (this.sm) this.sm.file('require.js', req);
 
   // build the source
-  var src = this.pkg(this.entry);
+  var src = this.pkg(entry);
 
   // global support
-  var id = this.remap(this.entry).id;
+  var id = this.remap(entry).id;
   var m = {};
   m[id] = entry.global || '';
 
   // umd support
-  if (this.opts.umd && this.entry.name) {
+  if (this.opts.umd && entry.name) {
     str = fmt('%s(%s);', umd
-      .replace(/:entry/g, this.entry.name)
+      .replace(/:entry/g, entry.name)
       .replace(/:id/g, id)
       , str);
   }
 
-  if (this.sm) {
-    str += '\n\n';
-    if (this.sm.inline) str += this.sm.end();
-    else str += '//# sourceMappingURL=' + this.entry.id + '.map';
-  }
+  if (this.sm) str += '\n\n' + this.sm.comment();
 
   return fmt(str, req, join(src), stringify(m));
 };
@@ -112,7 +108,7 @@ JS.prototype.code = function() {
 JS.prototype.map = function () {
   if (!this.sm) return false;
   if (this.sm.inline) return false;
-  return this.sm.end();
+  return this.sm.external();
 }
 
 /**

--- a/lib/js/index.js
+++ b/lib/js/index.js
@@ -29,7 +29,8 @@ module.exports = JS;
 
 function JS(entry, mapping, pack) {
   if (!(this instanceof JS)) return new JS(entry, mapping, pack);
-  this.sm = this.sourceMap(pack.sourceMap());
+
+  this.sm = this.sourceMap(entry.id, pack.sourceMap());
   this.mapping = mapping;
   this.opts = pack.opts;
   this.entry = entry;
@@ -39,14 +40,15 @@ function JS(entry, mapping, pack) {
 }
 
 /**
- * Sets up the source-map based on `value`.
+ * Sets up the source-map.
  *
+ * @param {String} entry          the entry file id
  * @param {Boolean|String} value  true/false/'inline'
  */
 
-JS.prototype.sourceMap = function (value) {
-  if (!value) return false;
-  return sourcemap(value === 'inline');
+JS.prototype.sourceMap = function (entry, state) {
+  if (!state) return false;
+  return sourcemap(entry, state === 'inline');
 }
 
 /**
@@ -92,7 +94,11 @@ JS.prototype.code = function() {
       , str);
   }
 
-  if (this.sm && this.sm.inline) str += '\n\n' + this.sm.end();
+  if (this.sm) {
+    str += '\n\n';
+    if (this.sm.inline) str += this.sm.end();
+    else str += '//# sourceMappingURL=' + this.entry.id + '.map';
+  }
 
   return fmt(str, req, join(src), stringify(m));
 };

--- a/lib/js/index.js
+++ b/lib/js/index.js
@@ -29,13 +29,24 @@ module.exports = JS;
 
 function JS(entry, mapping, pack) {
   if (!(this instanceof JS)) return new JS(entry, mapping, pack);
-  this.sm = pack.develop ? sourcemap() : false;
+  this.sm = this.sourceMap(pack.sourceMap());
   this.mapping = mapping;
   this.opts = pack.opts;
   this.entry = entry;
   this.pack = pack;
   this.ids = {};
   this.uid = 0;
+}
+
+/**
+ * Sets up the source-map based on `value`.
+ *
+ * @param {Boolean|String} value  true/false/'inline'
+ */
+
+JS.prototype.sourceMap = function (value) {
+  if (!value) return false;
+  return sourcemap(value === 'inline');
 }
 
 /**
@@ -49,7 +60,7 @@ JS.prototype.run = function () {
   return {
     code: this.code(),
     map: this.map()
-  }
+  };
 };
 
 /**
@@ -81,6 +92,8 @@ JS.prototype.code = function() {
       , str);
   }
 
+  if (this.sm && this.sm.inline) str += '\n\n' + this.sm.end();
+
   return fmt(str, req, join(src), stringify(m));
 };
 
@@ -92,6 +105,7 @@ JS.prototype.code = function() {
 
 JS.prototype.map = function () {
   if (!this.sm) return false;
+  if (this.sm.inline) return false;
   return this.sm.end();
 }
 

--- a/lib/js/sourcemap.js
+++ b/lib/js/sourcemap.js
@@ -15,9 +15,10 @@ module.exports = Sourcemap;
  * Initialize `Sourcemap`
  */
 
-function Sourcemap(inline) {
-  if (!(this instanceof Sourcemap)) return new Sourcemap(inline);
-  this.sm = sourcemap.create();
+function Sourcemap(entry, inline) {
+  if (!(this instanceof Sourcemap)) return new Sourcemap(entry, inline);
+
+  this.sm = sourcemap.create(entry);
   this.inline = !!inline;
   this.lineno = 0;
 }

--- a/lib/js/sourcemap.js
+++ b/lib/js/sourcemap.js
@@ -3,6 +3,7 @@
  */
 
 var convert = require('convert-source-map');
+var path = require('path');
 var sourcemap = require('combine-source-map');
 
 /**
@@ -20,6 +21,7 @@ function Sourcemap(entry, inline) {
 
   this.sm = sourcemap.create(entry);
   this.inline = !!inline;
+  this.entry = entry;
   this.lineno = 0;
 }
 
@@ -38,16 +40,27 @@ Sourcemap.prototype.file = function(file, src, wrapped) {
 };
 
 /**
- * End the sourcemap
+ * Render a source-map comment.
  *
  * @return {String}
  * @api public
  */
 
-Sourcemap.prototype.end = function() {
+Sourcemap.prototype.comment = function() {
   return this.inline
     ? this.sm.comment()
-    : convert.fromBase64(this.sm.base64()).toJSON();
+    : '//# sourceMappingURL=' + path.basename(this.entry) + '.map';
+};
+
+/**
+ * Render an external source-map file.
+ *
+ * @return {String}
+ * @api public
+ */
+
+Sourcemap.prototype.external = function () {
+  return convert.fromBase64(this.sm.base64()).toJSON()
 };
 
 /**

--- a/lib/js/sourcemap.js
+++ b/lib/js/sourcemap.js
@@ -46,7 +46,7 @@ Sourcemap.prototype.file = function(file, src, wrapped) {
 Sourcemap.prototype.end = function() {
   return this.inline
     ? this.sm.comment()
-    : convert.fromBase64(this.sm.base64()).toObject();
+    : convert.fromBase64(this.sm.base64()).toJSON();
 };
 
 /**

--- a/lib/js/sourcemap.js
+++ b/lib/js/sourcemap.js
@@ -15,9 +15,10 @@ module.exports = Sourcemap;
  * Initialize `Sourcemap`
  */
 
-function Sourcemap() {
-  if (!(this instanceof Sourcemap)) return new Sourcemap();
+function Sourcemap(inline) {
+  if (!(this instanceof Sourcemap)) return new Sourcemap(inline);
   this.sm = sourcemap.create();
+  this.inline = !!inline;
   this.lineno = 0;
 }
 
@@ -43,7 +44,9 @@ Sourcemap.prototype.file = function(file, src, wrapped) {
  */
 
 Sourcemap.prototype.end = function() {
-  return convert.fromBase64(this.sm.base64()).toObject();
+  return this.inline
+    ? this.sm.comment()
+    : convert.fromBase64(this.sm.base64()).toObject();
 };
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,5 @@
 
+var convert = require('convert-source-map');
 var read = require('fs').readFileSync;
 var assert = require('assert');
 var fs = require('co-fs');
@@ -115,11 +116,18 @@ describe('Pack', function(){
     assert(!js.map);
   })
 
-  it('should contain sourcemaps when development is set', function(){
+  it('should contain sourcemaps when sourceMap is set', function(){
     var map = require('./fixtures/sourcemaps');
-    var js = Pack(map).development().pack('m');
+    var js = Pack(map).sourceMap(true).pack('m');
     assert(map.m.src == js.map.sourcesContent[js.map.sources.indexOf('/duo/m')]);
   })
+
+  it('should append an inline source-map to code when sourceMap is "inline"', function () {
+    var map = require('./fixtures/sourcemaps');
+    var js = Pack(map).sourceMap('inline').pack('m');
+    var sourceMap = convert.fromSource(js.code).toObject();
+    assert(map.m.src == sourceMap.sourcesContent[sourceMap.sources.indexOf('/duo/m')]);
+  });
 
   it('should handle css files', function() {
     var map = {};

--- a/test/index.js
+++ b/test/index.js
@@ -119,16 +119,21 @@ describe('Pack', function(){
   it('should contain sourcemaps when sourceMap is set', function(){
     var map = require('./fixtures/sourcemaps');
     var js = Pack(map).sourceMap(true).pack('m');
+
+    // should link from code to map
+    assert(/\/\/# sourceMappingURL=m\.map$/.test(js.code));
+
+    // should include external map source
     var sourceMap = convert.fromJSON(js.map).toObject();
-    assert(map.m.src == sourceMap.sourcesContent[sourceMap.sources.indexOf('/duo/m')]);
+    assert.equal(map.m.src, sourceMap.sourcesContent[sourceMap.sources.indexOf('/duo/m')]);
   })
 
-  it('should append an inline source-map to code when sourceMap is "inline"', function () {
+  it('should append an inline source-map to code when sourceMap is "inline"', function(){
     var map = require('./fixtures/sourcemaps');
     var js = Pack(map).sourceMap('inline').pack('m');
     var sourceMap = convert.fromSource(js.code).toObject();
-    assert(map.m.src == sourceMap.sourcesContent[sourceMap.sources.indexOf('/duo/m')]);
-  });
+    assert.equal(map.m.src, sourceMap.sourcesContent[sourceMap.sources.indexOf('/duo/m')]);
+  })
 
   it('should handle css files', function() {
     var map = {};

--- a/test/index.js
+++ b/test/index.js
@@ -110,13 +110,13 @@ describe('Pack', function(){
 
   it('should not contain sourcemaps by default', function(){
     var map = {};
-    map.m = { id: 'm', type: 'js', entry: true, src: 'module.exports = "m"', deps: {} }
+    map.m = { id: 'm', type: 'js', entry: true, src: 'module.exports = "m"', deps: {} };
     var pack = Pack(map);
     var js = pack.pack('m');
     assert(!js.map);
   })
 
-  it('should contain sourcemaps when sourceMap is set', function(){
+  it('should reference an external source-map', function(){
     var map = require('./fixtures/sourcemaps');
     var js = Pack(map).sourceMap(true).pack('m');
 
@@ -126,6 +126,15 @@ describe('Pack', function(){
     // should include external map source
     var sourceMap = convert.fromJSON(js.map).toObject();
     assert.equal(map.m.src, sourceMap.sourcesContent[sourceMap.sources.indexOf('/duo/m')]);
+  })
+
+  it('should reference the external source-map via relative path', function(){
+    var mapping = {};
+    mapping['a/b/c.js'] = { id: 'a/b/c.js', type: 'js', entry: true, src: 'module.exports = true;', deps: {} };
+    var js = Pack(mapping).sourceMap(true).pack('a/b/c.js');
+
+    // should link from code to map
+    assert(/\/\/# sourceMappingURL=c\.js\.map$/.test(js.code));
   })
 
   it('should append an inline source-map to code when sourceMap is "inline"', function(){

--- a/test/index.js
+++ b/test/index.js
@@ -119,7 +119,8 @@ describe('Pack', function(){
   it('should contain sourcemaps when sourceMap is set', function(){
     var map = require('./fixtures/sourcemaps');
     var js = Pack(map).sourceMap(true).pack('m');
-    assert(map.m.src == js.map.sourcesContent[js.map.sources.indexOf('/duo/m')]);
+    var sourceMap = convert.fromJSON(js.map).toObject();
+    assert(map.m.src == sourceMap.sourcesContent[sourceMap.sources.indexOf('/duo/m')]);
   })
 
   it('should append an inline source-map to code when sourceMap is "inline"', function () {


### PR DESCRIPTION
This makes a few changes to make dealing with source-maps easier for duo upstream and likely plugin authors and other people using the JS API.

First, when source-maps is set to `inline`, the comment is directly appended to `results.code`. This prevents upstream from needing to care about inline vs external when writing files. It's also what I would expect, since that's what babel does when you set `sourceMap: 'inline'` in their config.

Second, when source-maps is set to `true`, (ie: external) then `results.map` is just the string that would be written to `entry.js.map`. This also spares upstream from needing to care about the format of the source maps, if it sees `results.map` it just proceeds and pipes it directly to a file.

Third, in the context of the previous step, it also appends the appropriate comment to `results.code`. (ie: `//# sourceMappingURL={entry}.map`)

These are all breaking changes unfortunately, but I think these are necessary as we try to migrate to the plugin hooks, not to mention improving the interoperability for things like gulp. (lots of this logic is currently in `Duo#write()`, so people using `Duo#run()` have to worry about source-maps all over the place. :(