### PR TITLE
Using source-root internally

### DIFF
--- a/lib/js/sourcemap.js
+++ b/lib/js/sourcemap.js
@@ -19,7 +19,7 @@ module.exports = Sourcemap;
 function Sourcemap(entry, inline) {
   if (!(this instanceof Sourcemap)) return new Sourcemap(entry, inline);
 
-  this.sm = sourcemap.create(entry);
+  this.sm = sourcemap.create(entry, '/duo');
   this.inline = !!inline;
   this.entry = entry;
   this.lineno = 0;
@@ -35,7 +35,7 @@ function Sourcemap(entry, inline) {
 
 Sourcemap.prototype.file = function(file, src, wrapped) {
   var offset = wrapperOffset(src, wrapped);
-  this.sm.addFile({ sourceFile: '/duo/' + file, source: src }, { line: this.lineno + offset });
+  this.sm.addFile({ sourceFile: file, source: src }, { line: this.lineno + offset });
   this.lineno += lineno(wrapped || src);
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -125,7 +125,8 @@ describe('Pack', function(){
 
     // should include external map source
     var sourceMap = convert.fromJSON(js.map).toObject();
-    assert.equal(map.m.src, sourceMap.sourcesContent[sourceMap.sources.indexOf('/duo/m')]);
+    assert.equal(sourceMap.sourceRoot, '/duo');
+    assert.equal(map.m.src, sourceMap.sourcesContent[sourceMap.sources.indexOf('m')]);
   })
 
   it('should reference the external source-map via relative path', function(){
@@ -141,7 +142,8 @@ describe('Pack', function(){
     var map = require('./fixtures/sourcemaps');
     var js = Pack(map).sourceMap('inline').pack('m');
     var sourceMap = convert.fromSource(js.code).toObject();
-    assert.equal(map.m.src, sourceMap.sourcesContent[sourceMap.sources.indexOf('/duo/m')]);
+    assert.equal(sourceMap.sourceRoot, '/duo');
+    assert.equal(map.m.src, sourceMap.sourcesContent[sourceMap.sources.indexOf('m')]);
   })
 
   it('should handle css files', function() {


### PR DESCRIPTION
Came across a weird behavior when using `duo-babel` yesterday. Basically, without a `sourceRoot` defined, it would start concatenating paths in really weird ways when merging the source-maps. Examples include: `/duo/apps/home/client/index.js` -> `/duo/apps/home/client/apps/home/client/index.js`, which I imagine would just compound with each layer of source-maps transformation.

By adding `sourceRoot: '/duo'` in `duo-babel` itself, fixed the problem. That being said, I'm hoping that by including `sourceRoot` all the way at the bottom here, it should "bubble up" and other source-maps should just do the right thing. (without needing to know about the internals)

Also, was thinking if we wanted to, we could expose the `sourceRoot` option to duo users, in case they wanted to use something other that `'/duo'`. (but that's probably unnecessary)